### PR TITLE
Use publish for trimming assemblies

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Build Shared Library
         run: |
           cd dotnet
-          make build
+          make publish
       - name: Build pokedex.db
         run: |
           cd console

--- a/dotnet/Makefile
+++ b/dotnet/Makefile
@@ -1,7 +1,11 @@
 CONFIGURATION := Release
 DOTNET := dotnet
+JAVASCRIPT_PROJECT := ./src/JavaScript/src/dotnet.csproj
 
 .PHONY: publish
 
 build: 
-	$(DOTNET) $@ -c $(CONFIGURATION) ./src/JavaScript/src/dotnet.csproj
+	$(DOTNET) $@ -c $(CONFIGURATION) $(JAVASCRIPT_PROJECT)
+
+publish:
+	$(DOTNET) $@ -c $(CONFIGURATION) $(JAVASCRIPT_PROJECT)


### PR DESCRIPTION
fix: https://github.com/yamachu/pokedex-net-webassembly-without-blazor/issues/4