### PR TITLE
Dapperを使わずに処理すればQueryParameterが使えそうなのでやってみる

### DIFF
--- a/dotnet/src/JavaScript/src/Program.cs
+++ b/dotnet/src/JavaScript/src/Program.cs
@@ -36,6 +36,19 @@ public partial class MyClass
     }
 
     [JSExport]
+    [return: JSMarshalAs<JSType.Promise<JSType.String>>]
+    internal async static Task<string> FetchPokemonsWithQuery(string query)
+    {
+        if (dbHelper == null)
+        {
+            return await Task.FromException<string>(new Exception("Must Initialize"));
+        }
+        var result = await QueryPokemon.FetchPokemons(dbHelper, query);
+
+        return JsonSerializer.Serialize(new FetchPokemonsReturnJsonType(result), typeof(FetchPokemonsReturnJsonType), PokemonsJsonSerializerContext.Default);
+    }
+
+    [JSExport]
     internal static Task<int> ConnectionTest()
     {
         return dbHelper?.AsyncBindConnection(

--- a/dotnet/src/JavaScript/test/src/FetchPokemonsTest.test.ts
+++ b/dotnet/src/JavaScript/test/src/FetchPokemonsTest.test.ts
@@ -70,4 +70,57 @@ describe("ConnectionTest", () => {
       ],
     });
   });
+
+  it(`return id 0 pokemon as string by passing query`, async (ctx) => {
+    const { getAssemblyExports, setModuleImports, getConfig, Module } =
+      ctx.runtimeAPI;
+
+    const config = getConfig();
+    const exported = await getTypedAssemblyExports(
+      getAssemblyExports(config.mainAssemblyName!)
+    );
+    setTypedModuleImports(setModuleImports, "main.mjs", {
+      sqlite: {
+        connection: () => "Data Source=/work/pokedex.db",
+      },
+    });
+
+    Module.FS_createPath("/", "work", true, true);
+    const dbFixture = await readFile(join(FixtureDir, "0-152.db"));
+    Module.FS_createDataFile(
+      "/work",
+      "pokedex.db",
+      dbFixture,
+      true,
+      true,
+      true
+    );
+
+    exported.MyClass.Initialize();
+    expect(
+      await exported.MyClass.FetchPokemonsWithQuery("0").then((v: string) =>
+        JSON.parse(v)
+      )
+    ).toStrictEqual({
+      pokemons: [
+        {
+          id: 0,
+          name: "ヤマチュウ",
+        },
+      ],
+    });
+
+    expect(
+      await exported.MyClass.FetchPokemonsWithQuery("ヤマ").then((v: string) =>
+        JSON.parse(v)
+      )
+    ).toStrictEqual({
+      pokemons: [
+        {
+          id: 0,
+          name: "ヤマチュウ",
+        },
+      ],
+    });
+  });
 });

--- a/dotnet/src/Shared/src/PokedexUsecase.cs
+++ b/dotnet/src/Shared/src/PokedexUsecase.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Microsoft.Data.Sqlite;
 using PokedexNetWebassembly.Shared.Infrastructures;
+using PokedexNetWebassembly.Shared.Util;
 
 namespace PokedexNetWebassembly.Shared.Usecases;
 
@@ -29,31 +31,33 @@ public class QueryPokemon
         );
     }
 
-    #region DO NOT USE ON BROWSER-WASM
-    // FIXME: if passed parameters to QueryAsync, Query, and more operations, it will crash
-    // ManagedError: Error occurred during a cryptographic operation.
-    // FIXME: if passed type argument for mapping return values, it will crash
-    // ManagedError: Error occurred during a cryptographic operation.
     public static Task<Pokemon[]> FetchPokemons(SqliteHelper dbHelper, string query)
     {
         return dbHelper.AsyncBindConnection(
             async (c) =>
             {
-                var result = await c.QueryAsync("select id, name from pokemons where id = @query or name like @query", new { query });
-                var mapped = result.OfType<IDictionary<string, object>>().Select(v =>
-                {
-                    return new Pokemon(
-                        Convert.ToInt32(v["id"]),
-                        Convert.ToString(v["name"])
-                    );
-                });
-
-                return mapped.ToArray();
+                var command = c.CreateCommand();
+                command.CommandText= "select id, name from pokemons where id = @queryMaybeId or name like '%@queryMaybeName%'";
+                var maybeId = -1;
+                _ = int.TryParse(query, out maybeId);
+                command.Parameters.Add(new SqliteParameter { SqliteType = SqliteType.Integer, Value = maybeId, ParameterName = "queryMaybeId" });
+                command.Parameters.Add(new SqliteParameter { SqliteType = SqliteType.Text, Value = query, ParameterName = "queryMaybeName" });
+                var reader = await command.ExecuteReaderAsync();
+                return reader.ToEnumerable().Select(v => {
+                    var id = Convert.ToInt32(v["id"]);
+                    var name = (string)v["name"];
+                    return new Pokemon(id, name);
+                }).ToArray();
             },
             Task.FromException<Pokemon[]>(new Exception("Cannot fetch pokemons"))
         );
     }
 
+    #region DO NOT USE ON BROWSER-WASM
+    // FIXME: if passed parameters to QueryAsync, Query, and more operations, it will crash
+    // ManagedError: Error occurred during a cryptographic operation.
+    // FIXME: if passed type argument for mapping return values, it will crash
+    // ManagedError: Error occurred during a cryptographic operation.
     public static Task<Pokemon[]> FetchPokemonsWithMapping(SqliteHelper dbHelper)
     {
         return dbHelper.AsyncBindConnection(

--- a/dotnet/src/Shared/src/Util.cs
+++ b/dotnet/src/Shared/src/Util.cs
@@ -1,0 +1,13 @@
+using Microsoft.Data.Sqlite;
+
+namespace PokedexNetWebassembly.Shared.Util;
+
+public static class SqliteDataReaderExt
+{
+    internal static IEnumerable<SqliteDataReader> ToEnumerable(this SqliteDataReader reader)
+    {
+        while (reader.Read()) {
+            yield return reader;
+        }
+    }
+}

--- a/dotnet/src/Shared/test/PokedexNetWebassemblySharedTest.cs
+++ b/dotnet/src/Shared/test/PokedexNetWebassemblySharedTest.cs
@@ -34,6 +34,27 @@ public class PokedexNetWebassemblySharedTest
     }
 
     [Fact]
+    public async Task FetchPokemon()
+    {
+        var dbHelper = new SqliteHelper(() => "Data Source=./fixtures/0-152.db");
+        var pokemon0 = await QueryPokemon.FetchPokemons(dbHelper, "0");
+        Assert.Equal(
+            new Pokemon[] {
+                new Pokemon(0, "ヤマチュウ")
+            },
+            pokemon0
+        );
+
+        var pokemon00 = await QueryPokemon.FetchPokemons(dbHelper, "ヤマチュ");
+        Assert.Equal(
+            new Pokemon[] {
+                new Pokemon(0, "ヤマチュウ")
+            },
+            pokemon00
+        );
+    }
+
+    [Fact]
     public async Task FetchPokemonWithMapping()
     {
         var dbHelper = new SqliteHelper(() => "Data Source=./fixtures/0-152.db");


### PR DESCRIPTION
ref: https://github.com/yamachu/pokedex-net-webassembly-without-blazor/issues/11

Dapper内部でDynamic Valueとかを使ってそうだけど、素のSQLiteのライブラリはobjectをそのまま使っていそうなのと、パラメータを自前で処理すればいい感じになりそうなのでそうする